### PR TITLE
Update config.toml file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://example.com/"
+baseURL = "/"
 languageCode = "en-us"
 title = "Data Science Garage"
 theme = "minimal"


### PR DESCRIPTION
Changed the baseURL to "/" as the example provided causes the css file path to become corrupt, which is why it wasn't displaying correctly when built from netlify.